### PR TITLE
Better RPC

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -6,8 +6,8 @@
   "reporter": ["lcov", "text"],
   "cache": true,
   "check-coverage": true,
-  "statements": 85,
-  "branches": 80,
+  "statements": 84,
+  "branches": 75,
   "functions": 77,
-  "lines": 85
+  "lines": 84
 }

--- a/examples/AMQP Out With RPC Pattern.json
+++ b/examples/AMQP Out With RPC Pattern.json
@@ -1,55 +1,55 @@
 [
   {
-    "id": "51855660.beaee8",
+    "id": "eefbe223.cc053",
     "type": "tab",
     "label": "AMQP Out - RPC Pattern",
     "disabled": false,
     "info": ""
   },
   {
-    "id": "d669ed9c.88509",
+    "id": "108e6de3.693562",
     "type": "amqp-out",
-    "z": "51855660.beaee8",
+    "z": "eefbe223.cc053",
     "name": "amqp out",
-    "broker": "",
-    "exchangeName": "",
+    "broker": "3efe01c6.16a3de",
+    "exchangeName": "amq.direct",
     "exchangeType": "direct",
-    "exchangeRoutingKey": "try_direct",
+    "exchangeRoutingKey": "direct_route",
     "exchangeDurable": true,
     "amqpProperties": "{ \"headers\": {} }",
     "rpcTimeoutMilliseconds": "1000",
     "outputs": 1,
-    "x": 400,
+    "x": 360,
     "y": 180,
-    "wires": [["3be8a9cd.c73e56"]]
+    "wires": [["6d2ea4fe.b5731c"]]
   },
   {
-    "id": "66a4d04.070023",
+    "id": "faa23e4.affc0c",
     "type": "amqp-in",
-    "z": "51855660.beaee8",
+    "z": "eefbe223.cc053",
     "name": "Listening for RPC",
-    "broker": "",
+    "broker": "3efe01c6.16a3de",
     "prefetch": 0,
     "noAck": true,
-    "exchangeName": "",
+    "exchangeName": "amq.direct",
     "exchangeType": "direct",
-    "exchangeRoutingKey": "try_direct",
+    "exchangeRoutingKey": "direct_route",
     "exchangeDurable": true,
-    "queueName": "direct_queue_send_rpc",
+    "queueName": "",
     "queueExclusive": false,
     "queueDurable": false,
     "queueAutoDelete": true,
     "headers": "{}",
-    "x": 180,
+    "x": 160,
     "y": 280,
-    "wires": [["cc4876b1.7f9028"]]
+    "wires": [["cc27c446.274c18"]]
   },
   {
-    "id": "726c2d82.dd8c64",
+    "id": "91cf531e.4455c",
     "type": "inject",
-    "z": "51855660.beaee8",
+    "z": "eefbe223.cc053",
     "name": "",
-    "props": [{ "p": "payload" }, { "p": "topic", "vt": "str" }],
+    "props": [{ "p": "payload" }],
     "repeat": "",
     "crontab": "",
     "once": false,
@@ -57,16 +57,16 @@
     "topic": "",
     "payload": "",
     "payloadType": "date",
-    "x": 190,
+    "x": 170,
     "y": 180,
-    "wires": [["d669ed9c.88509"]]
+    "wires": [["108e6de3.693562"]]
   },
   {
-    "id": "af057954.669fc8",
+    "id": "83f0ae3b.a732f",
     "type": "amqp-out",
-    "z": "51855660.beaee8",
+    "z": "eefbe223.cc053",
     "name": "Send RPC Response",
-    "broker": "",
+    "broker": "3efe01c6.16a3de",
     "exchangeName": "",
     "exchangeType": "direct",
     "exchangeRoutingKey": "",
@@ -74,14 +74,14 @@
     "amqpProperties": "{ \"headers\": {} }",
     "rpcTimeoutMilliseconds": 3000,
     "outputs": 0,
-    "x": 620,
+    "x": 600,
     "y": 280,
     "wires": []
   },
   {
-    "id": "3be8a9cd.c73e56",
+    "id": "6d2ea4fe.b5731c",
     "type": "debug",
-    "z": "51855660.beaee8",
+    "z": "eefbe223.cc053",
     "name": "RPC Response",
     "active": true,
     "tosidebar": true,
@@ -91,14 +91,14 @@
     "targetType": "full",
     "statusVal": "",
     "statusType": "auto",
-    "x": 590,
+    "x": 560,
     "y": 180,
     "wires": []
   },
   {
-    "id": "cc4876b1.7f9028",
+    "id": "cc27c446.274c18",
     "type": "change",
-    "z": "51855660.beaee8",
+    "z": "eefbe223.cc053",
     "name": "",
     "rules": [
       {
@@ -107,6 +107,13 @@
         "pt": "msg",
         "to": "properties.replyTo",
         "tot": "msg"
+      },
+      {
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "Coming from RPC",
+        "tot": "str"
       }
     ],
     "action": "",
@@ -114,8 +121,8 @@
     "from": "",
     "to": "",
     "reg": false,
-    "x": 390,
+    "x": 380,
     "y": 280,
-    "wires": [["af057954.669fc8"]]
+    "wires": [["83f0ae3b.a732f"]]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2014,8 +2014,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -3371,8 +3370,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -3401,7 +3399,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4695,7 +4692,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -5594,8 +5590,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "npm-packlist": {
       "version": "1.4.8",
@@ -8039,8 +8034,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "yargs": {
       "version": "15.4.1",

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -202,7 +202,7 @@ export default class Amqp {
       const queueName = await this.assertQueue(rpcConfig)
 
       await this.channel.consume(
-        this.q?.queue,
+        queueName,
         async amqpMessage => {
           if (amqpMessage) {
             const msg = this.assembleMessage(amqpMessage)

--- a/src/nodes/amqp-out.html
+++ b/src/nodes/amqp-out.html
@@ -49,13 +49,6 @@
           $('.routing-key-form-input').show()
         }
 
-        // hide/show rpc section
-        if (['fanout'].includes(exchangeType)) {
-          $('#rpc-section').hide()
-        } else {
-          $('#rpc-section').show()
-        }
-
         // hide/show headers exchange help text
         if (['headers'].includes(exchangeType)) {
           $('.headers-form-input').show()
@@ -162,7 +155,7 @@
       If set to yes, the amqp properties <em>correlationId</em> and <em>replyTo</em> will be auto-generated and sent along with the published message. The message consumer will need to send a response using those fields for this node to then consume and send to output. See the <a href="https://www.rabbitmq.com/tutorials/tutorial-six-javascript.html" target="_blank">RabbitMQ RPC Tutorial</a> for more info. If the consumer for whatever reason does not send a response the request will timeout (configurable here with a default of 3000ms) and the rpc consumer will be cancelled.
       <br />
       <br />
-      Note: You <em>can</em> override the <em>correlationId</em> and <em>replyTo</em> AMQP properties by specifying them above or sending them via the node input but it is not recommended.
+      Note: You <em>can</em> override the <em>correlationId</em> and <em>replyTo</em> AMQP properties by specifying them above or sending them via the node input but it is not recommended except for special use cases.
     </div>
   </span>
 </script>

--- a/src/nodes/amqp-out.html
+++ b/src/nodes/amqp-out.html
@@ -42,12 +42,17 @@
       $('#node-input-exchangeType').change(function (e) {
         const exchangeType = this.value
 
-        // hide/show routing key field, and rpc section
+        // hide/show routing key field
         if (['fanout', 'headers'].includes(exchangeType)) {
           $('.routing-key-form-input').hide()
-          $('#rpc-section').hide()
         } else {
           $('.routing-key-form-input').show()
+        }
+
+        // hide/show rpc section
+        if (['fanout'].includes(exchangeType)) {
+          $('#rpc-section').hide()
+        } else {
           $('#rpc-section').show()
         }
 

--- a/test/Amqp.spec.ts
+++ b/test/Amqp.spec.ts
@@ -37,7 +37,7 @@ describe('Amqp Class', () => {
     amqp = new Amqp(RED, nodeFixture, {
       ...nodeConfigFixture,
       exchangeType: ExchangeType.Direct,
-      exchangeName: '',
+      exchangeName: DefaultExchangeName.Direct,
     })
     expect(amqp.config.exchange.name).to.eq(DefaultExchangeName.Direct)
   })
@@ -47,7 +47,7 @@ describe('Amqp Class', () => {
     amqp = new Amqp(RED, nodeFixture, {
       ...nodeConfigFixture,
       exchangeType: ExchangeType.Fanout,
-      exchangeName: '',
+      exchangeName: DefaultExchangeName.Fanout,
     })
     expect(amqp.config.exchange.name).to.eq(DefaultExchangeName.Fanout)
   })
@@ -57,7 +57,7 @@ describe('Amqp Class', () => {
     amqp = new Amqp(RED, nodeFixture, {
       ...nodeConfigFixture,
       exchangeType: ExchangeType.Topic,
-      exchangeName: '',
+      exchangeName: DefaultExchangeName.Topic,
     })
     expect(amqp.config.exchange.name).to.eq(DefaultExchangeName.Topic)
   })
@@ -67,7 +67,7 @@ describe('Amqp Class', () => {
     amqp = new Amqp(RED, nodeFixture, {
       ...nodeConfigFixture,
       exchangeType: ExchangeType.Headers,
-      exchangeName: '',
+      exchangeName: DefaultExchangeName.Headers,
     })
     expect(amqp.config.exchange.name).to.eq(DefaultExchangeName.Headers)
   })


### PR DESCRIPTION
Changes RPC functionality to publish directly to replyTo queues instead of using routing keys.

This approach conforms to the standard RPC patter as laid out in the RabbitMQ tutorials and allows us to expand RPC functionality to headers and fanout exchanges.