### PR TITLE
Encode username and password in percent-encoding format

### DIFF
--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -1,7 +1,6 @@
 import { NodeRedApp, Node } from 'node-red'
 import { v4 as uuidv4 } from 'uuid'
 import cloneDeep = require('lodash.clonedeep')
-import * as querystring from 'querystring';
 import {
   Connection,
   Channel,
@@ -357,7 +356,7 @@ export default class Amqp {
         : credentials
 
       const protocol = tls ? /* istanbul ignore next */ 'amqps' : 'amqp'
-      url = `${protocol}://${querystring.escape(username)}:${querystring.escape(password)}@${host}:${port}/${vhost}`
+      url = `${protocol}://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:${port}/${vhost}`
     }
 
     return url

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -1,6 +1,7 @@
 import { NodeRedApp, Node } from 'node-red'
 import { v4 as uuidv4 } from 'uuid'
 import cloneDeep = require('lodash.clonedeep')
+import * as querystring from 'querystring';
 import {
   Connection,
   Channel,
@@ -356,7 +357,7 @@ export default class Amqp {
         : credentials
 
       const protocol = tls ? /* istanbul ignore next */ 'amqps' : 'amqp'
-      url = `${protocol}://${username}:${password}@${host}:${port}/${vhost}`
+      url = `${protocol}://${querystring.escape(username)}:${querystring.escape(password)}@${host}:${port}/${vhost}`
     }
 
     return url

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -356,7 +356,9 @@ export default class Amqp {
         : credentials
 
       const protocol = tls ? /* istanbul ignore next */ 'amqps' : 'amqp'
-      url = `${protocol}://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:${port}/${vhost}`
+      url = `${protocol}://${encodeURIComponent(username)}:${encodeURIComponent(
+        password,
+      )}@${host}:${port}/${vhost}`
     }
 
     return url


### PR DESCRIPTION
**The Issue**
If the username or password contains any special character, the connection to RabbitMQ server would fail.

According to the [amqplib document](https://www.squaremobius.net/amqp.node/channel_api.html#auth), usernames and passwords should be [percent-encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).

**The Workaround**
You can use existing online tool such as [urlencoder](https://www.urlencoder.org/) to manually convert username or password to percent-encoded format while setting the connection parameters.

**The PR**
This PR uses [escape()](https://nodejs.org/docs/latest-v12.x/api/querystring.html#querystring_querystring_escape_str) method to encode username and password into amqplib expected format.