### PR TITLE
Publish to a Queue using RoutingKey in Default Exchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meowwolf/node-red-contrib-amqp",
   "license": "ISC",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Amqp nodes for node-red",
   "main": "index.js",
   "scripts": {

--- a/src/Amqp.ts
+++ b/src/Amqp.ts
@@ -191,11 +191,20 @@ export default class Amqp {
           options,
         )
       } else {
-        this.channel.sendToQueue(
-          options.replyTo,
-          Buffer.from(msg as string),
-          options,
-        )
+        if (options.replyTo) {
+          this.channel.sendToQueue(
+            options.replyTo,
+            Buffer.from(msg as string),
+            options,
+          )
+        } else {
+          this.channel.publish(
+            "",
+            routingKey,
+            Buffer.from(msg as string),
+            options,
+          )
+        }
       }
     } catch (e) {
       this.node.error(`Could not publish message: ${e}`)


### PR DESCRIPTION
Hello,

I have seen that when an input node is generated, to send messages directly to a queue using the default exchange, it does not use the value of routingKey as the name of the queue and because of that the messages are lost due to routing failure.

From what I've seen, the value of replyTo can be used to make sending the message work correctly, but it doesn't seem intuitive to the user.

I haven't reviewed all the code and I don't know if the pull request is valid, but the tests I have done do not modify the normal operation and prevent the routingKey value from being used incorrectly.